### PR TITLE
add changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 /task/metadata.json
 /task/specification
 /task/issue
+
+# python
+.venv

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,14 @@ clobber::
 build-image::
 	docker build -t collection-task:latest .
  
+ make run::
+	cd task; \
+	./run.sh;
+
+make clean::
+	cd task; \
+	make clean;
+
+make clobber::
+	cd task; \
+	make clobber;

--- a/README.md
+++ b/README.md
@@ -52,3 +52,16 @@ or run the bash script that's used in the docker image. (if you haven't added a 
 ```
 ./run.sh
 ```
+
+Equally make rules havebeen set up in the root of the repository which allow you to run  the ./run.sh without changing to the task folder. e.g.
+
+```
+make run COLLECTION_NAME=<insert_collection_name_here>
+```
+
+you can include other environment variables to control the task
+
+```
+make run COLLECTION_NAME=<insert_collection_name_here> TRANSFORMED_JOBS=8
+```
+make clean and make clobber have also been set up to clear the task folder

--- a/task/run.sh
+++ b/task/run.sh
@@ -9,6 +9,14 @@ if [ -z "$COLLECTION_DATASET_BUCKET_NAME" ]; then
     echo "assign value to COLLECTION_DATASET_BUCKET_NAME to save to a bucket" 
 fi
 
+if [ -z "$TRANSFORMED_JOBS" ]; then
+    TRANSFORMED_JOBS=8
+fi
+
+if [ -z "$DATASET_JOBS" ]; then
+    DATASET_JOBS=8
+fi
+
 echo Install dependencies
 make init
 
@@ -20,7 +28,7 @@ if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
     make save-resources
     make save-logs
 else
-    echo "No COLECTION_DATASET_BUCKET_NAME defined so collection fies not pushed to s3"
+    echo "No COLECTION_DATASET_BUCKET_NAME defined so collection files not pushed to s3"
 fi
 
 echo Build the collection database
@@ -32,24 +40,24 @@ if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
 fi
 
 echo Transform collected files
-make transformed -j 8
+gmake transformed -j $TRANSFORMED_JOBS
 
 if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
     echo Save transformed files to Prod S3
     make save-transformed
 else
-    echo "No COLECTION_DATASET_BUCKET_NAME defined so transformed fies not pushed to s3"
+    echo "No COLECTION_DATASET_BUCKET_NAME defined so transformed files not pushed to s3"
 fi
 
 echo Build datasets from the transformed files
-make dataset -j 4
+gmake dataset -j $DATASET_JOBS
 
 if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
     echo Save datasets and expecations to Prod S3
     make save-dataset
     make save-expectations
 else
-    echo "No COLECTION_DATASET_BUCKET_NAME defined so dataset and expectation fies not pushed to s3"
+    echo "No COLECTION_DATASET_BUCKET_NAME defined so dataset and expectation files not pushed to s3"
 fi
    
 # TODO: send notifications of errors


### PR DESCRIPTION
Add two environment variables:
- TRANSFORMED_JOBS - allows the user to set the number of jobs to run at once when transforming resources
- DATASET_JOBS - allows the user to set the number of jobs to run at once when building datasets.

Associated Ticket:
[[https://trello.com/c/gXHi6zn8/3459-add-manual-options-for-collection-dags?filter=label:Infrastructure]]