### PR TITLE
Saving log.csv & resource.csv if incremental loading enabled

### DIFF
--- a/task/run.sh
+++ b/task/run.sh
@@ -49,6 +49,8 @@ else
                 --pipeline-dir=pipeline \
                 --state-path=state.json \
             && {
+                echo "Incremental loading enabled. Saving log.csv and resource.csv to $COLLECTION_DATASET_BUCKET_NAME."
+                make save-collection-log-resource
                 echo "Stopping processing as state hasn't changed."
                 exit 0
             }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Copies the log.csv and resource.csv file to S3 if incremental loading is enabled (at present this does not happen but should).

## Related Tickets & Documents
[#326](https://github.com/orgs/digital-land/projects/9/views/14?pane=issue&itemId=95524485&issue=digital-land%7Cdigital-land-python%7C326)
