### PR TITLE
Incremental loading: Stop processing if no new resources (and no state change)

### DIFF
--- a/task/makerules/makerules.mk
+++ b/task/makerules/makerules.mk
@@ -12,7 +12,7 @@ SOURCE_URL=https://raw.githubusercontent.com/digital-land/
 endif
 
 ifeq ($(MAKERULES_URL),)
-MAKERULES_URL=$(SOURCE_URL)makerules/new-resources-list/
+MAKERULES_URL=$(SOURCE_URL)makerules/main/
 endif
 
 ifeq ($(CONFIG_URL),)

--- a/task/makerules/makerules.mk
+++ b/task/makerules/makerules.mk
@@ -12,7 +12,7 @@ SOURCE_URL=https://raw.githubusercontent.com/digital-land/
 endif
 
 ifeq ($(MAKERULES_URL),)
-MAKERULES_URL=$(SOURCE_URL)makerules/main/
+MAKERULES_URL=$(SOURCE_URL)makerules/new-resources-list/
 endif
 
 ifeq ($(CONFIG_URL),)

--- a/task/run.sh
+++ b/task/run.sh
@@ -70,6 +70,10 @@ else
 		NEW_RESOURCES=True; \
 	fi
 
+    echo $STATE_CHANGED
+    echo "$$STATE_CHANGED"
+    echo $NEW_RESOURCES
+    echo "$$NEW_RESOURCES"
 	# Exit if both STATE_CHANGED=False and NEW_RESOURCES=False
 	if [ "$$STATE_CHANGED" = "False" ] && [ "$$NEW_RESOURCES" = "False" ]; then \
 		echo "No state change and no new resources. Exiting early."; \

--- a/task/run.sh
+++ b/task/run.sh
@@ -75,7 +75,7 @@ else
 fi
 
 echo Hello after incremental loading
-exit 0
+
 
 # if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
 #     echo Push collection database to $ENVIRONMENT S3

--- a/task/run.sh
+++ b/task/run.sh
@@ -70,13 +70,11 @@ else
 		NEW_RESOURCES=True; \
 	fi
 
-    echo $STATE_CHANGED
-    echo "$STATE_CHANGED"
-    echo $NEW_RESOURCES
-    echo "$NEW_RESOURCES"
 	# Exit if both STATE_CHANGED=False and NEW_RESOURCES=False
 	if [ "$STATE_CHANGED" = "False" ] && [ "$NEW_RESOURCES" = "False" ]; then \
-		echo "No state change and no new resources. Exiting early."; \
+        echo "Incremental loading enabled. Saving log.csv and resource.csv to $COLLECTION_DATASET_BUCKET_NAME."
+        make save-collection-log-resource
+		echo "No state change and no new resources. Stopping processing."; \
 		exit 0; \
 	fi
 

--- a/task/run.sh
+++ b/task/run.sh
@@ -65,6 +65,14 @@ else
     fi
 fi
 
+echo Determine new resources that have been downloaded
+aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun
+
+aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun > new_resources
+cat new_resources
+
+exit 0
+
 if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
     echo Push collection database to $ENVIRONMENT S3
     make save-collection

--- a/task/run.sh
+++ b/task/run.sh
@@ -30,7 +30,6 @@ echo Build the collection database
 make collection
 
 make new-resources-list
-exit 0
 
 # if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
 #     echo "Saving logs and resources to $COLLECTION_DATASET_BUCKET_NAME"
@@ -75,6 +74,8 @@ else
     fi
 fi
 
+echo Hello after incremental loading
+exit 0
 
 if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
     echo Push collection database to $ENVIRONMENT S3

--- a/task/run.sh
+++ b/task/run.sh
@@ -77,10 +77,10 @@ fi
 echo Hello after incremental loading
 exit 0
 
-if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
-    echo Push collection database to $ENVIRONMENT S3
-    make save-collection
-fi
+# if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
+#     echo Push collection database to $ENVIRONMENT S3
+#     make save-collection
+# fi
 
 echo Transform collected files
 gmake transformed -j $TRANSFORMED_JOBS

--- a/task/run.sh
+++ b/task/run.sh
@@ -29,6 +29,9 @@ make collect
 echo Build the collection database
 make collection
 
+make new-resources-list
+exit 0
+
 if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
     echo "Saving logs and resources to $COLLECTION_DATASET_BUCKET_NAME"
     make save-resources
@@ -65,8 +68,6 @@ else
     fi
 fi
 
-make new-resources-list
-exit 0
 
 if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
     echo Push collection database to $ENVIRONMENT S3

--- a/task/run.sh
+++ b/task/run.sh
@@ -71,11 +71,11 @@ else
 	fi
 
     echo $STATE_CHANGED
-    echo "$$STATE_CHANGED"
+    echo "$STATE_CHANGED"
     echo $NEW_RESOURCES
-    echo "$$NEW_RESOURCES"
+    echo "$NEW_RESOURCES"
 	# Exit if both STATE_CHANGED=False and NEW_RESOURCES=False
-	if [ "$$STATE_CHANGED" = "False" ] && [ "$$NEW_RESOURCES" = "False" ]; then \
+	if [ "$STATE_CHANGED" = "False" ] && [ "$NEW_RESOURCES" = "False" ]; then \
 		echo "No state change and no new resources. Exiting early."; \
 		exit 0; \
 	fi

--- a/task/run.sh
+++ b/task/run.sh
@@ -31,13 +31,13 @@ make collection
 
 make new-resources-list
 
-# if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
-#     echo "Saving logs and resources to $COLLECTION_DATASET_BUCKET_NAME"
-#     make save-resources
-#     make save-logs
-# else
-#     echo "No COLLECTION_DATASET_BUCKET_NAME defined so collection files not pushed to s3"
-# fi
+if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
+    echo "Saving logs and resources to $COLLECTION_DATASET_BUCKET_NAME"
+    make save-resources
+    make save-logs
+else
+    echo "No COLLECTION_DATASET_BUCKET_NAME defined so collection files not pushed to s3"
+fi
 
 if [ "$INCREMENTAL_LOADING_OVERRIDE" = "True" ]; then
     echo Incremental loading disabled as override flag is set.

--- a/task/run.sh
+++ b/task/run.sh
@@ -29,7 +29,8 @@ make collect
 echo Build the collection database
 make collection
 
-make new-resources-list
+echo Detect new resources that have been downloaded
+make detect-new-resources
 
 if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
     echo "Saving logs and resources to $COLLECTION_DATASET_BUCKET_NAME"
@@ -58,7 +59,7 @@ else
 			STATE_CHANGED=True; \
 		}; \
         else \
-            echo "Incremental loading disabled as no state.json found."; \
+            echo "No state.json found."; \
             STATE_CHANGED=True; \
         fi
 
@@ -70,7 +71,7 @@ else
 		NEW_RESOURCES=True; \
 	fi
 
-	# Exit if both STATE_CHANGED=False and NEW_RESOURCES=False
+	# Exit if the state is unchanged AND there are no new resources
 	if [ "$STATE_CHANGED" = "False" ] && [ "$NEW_RESOURCES" = "False" ]; then \
         echo "Incremental loading enabled. Saving log.csv and resource.csv to $COLLECTION_DATASET_BUCKET_NAME."
         make save-collection-log-resource
@@ -86,8 +87,6 @@ else
         echo "No COLLECTION_DATASET_BUCKET_NAME defined to get previous state.json"
     fi
 fi
-
-echo Hello after incremental loading
 
 
 if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then

--- a/task/run.sh
+++ b/task/run.sh
@@ -51,7 +51,7 @@ else
                 --pipeline-dir=pipeline \
                 --state-path=state.json \
             && { \
-			echo "Stopping processing as state hasn't changed."; \
+			echo "State is unchanged."; \
 			STATE_CHANGED=False; \
 		} || { \
             echo "State has changed."; \
@@ -88,10 +88,10 @@ fi
 echo Hello after incremental loading
 
 
-# if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
-#     echo Push collection database to $ENVIRONMENT S3
-#     make save-collection
-# fi
+if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
+    echo Push collection database to $ENVIRONMENT S3
+    make save-collection
+fi
 
 echo Transform collected files
 gmake transformed -j $TRANSFORMED_JOBS

--- a/task/run.sh
+++ b/task/run.sh
@@ -65,12 +65,7 @@ else
     fi
 fi
 
-echo Determine new resources that have been downloaded
-aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun
-
-aws s3 sync $(RESOURCE_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(REPOSITORY)/$(RESOURCE_DIR) --dryrun > new_resources
-cat new_resources
-
+make new-resources-list
 exit 0
 
 if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Adds detection of new resources to the run script (using a make rule in PR:https://github.com/digital-land/makerules/pull/81), and expands incremental loading.

Previously incremental loading would kick in when the state hadn't changed, and exit the run early.
Now, incremental loading will only kick in and exit early when the state hasn't changed AND there are no new resources detected, otherwise it will continue as normal

## Related Tickets & Documents

- Ticket Link https://github.com/orgs/digital-land/projects/9/views/3?pane=issue&itemId=93866679&issue=digital-land%7Ctechnical-documentation%7C234
