### PR TITLE
fix assmble.sh to only retain expectations file for the collection it…

### DIFF
--- a/bin/assemble.sh
+++ b/bin/assemble.sh
@@ -164,7 +164,7 @@ echo "Dataset flattened files created"
 # Fetch previous expectations from S3, to retain historic results on days expectations are skipped
 if [ -n "$COLLECTION_DATASET_BUCKET_NAME" ]; then
     echo "Fetching previous expectation results from S3..."
-    aws s3 sync s3://${COLLECTION_DATASET_BUCKET_NAME}/${OUTPUT_LOG_DIR}expectation/ ${OUTPUT_LOG_DIR}expectation/ --no-progress
+    aws s3 sync s3://${COLLECTION_DATASET_BUCKET_NAME}/${OUTPUT_LOG_DIR}expectation/dataset=${DATASET_NAME}/ ${OUTPUT_LOG_DIR}expectation/dataset=${DATASET_NAME}/ --no-progress
 fi
 
 

--- a/makerules/pipeline.mk
+++ b/makerules/pipeline.mk
@@ -258,7 +258,7 @@ endif
 
 save-expectations::
 	@mkdir -p $(OUTPUT_LOG_DIR)
-	aws s3 cp $(OUTPUT_LOG_DIR)expectation/dataset=$(DATASET_NAME)/$(DATASET_NAME).parquet s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(OUTPUT_LOG_DIR)expectation/dataset=$(DATASET_NAME)/$(DATASET_NAME).parquet
+	aws s3 sync $(OUTPUT_LOG_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(OUTPUT_LOG_DIR) --no-progress
 
 save-performance::
 	@mkdir -p $(PERFORMANCE_DIR)

--- a/makerules/pipeline.mk
+++ b/makerules/pipeline.mk
@@ -258,7 +258,7 @@ endif
 
 save-expectations::
 	@mkdir -p $(OUTPUT_LOG_DIR)
-	aws s3 sync $(OUTPUT_LOG_DIR) s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(OUTPUT_LOG_DIR) --no-progress
+	aws s3 cp $(OUTPUT_LOG_DIR)expectation/dataset=$(DATASET_NAME)/$(DATASET_NAME).parquet s3://$(COLLECTION_DATASET_BUCKET_NAME)/$(OUTPUT_LOG_DIR)expectation/dataset=$(DATASET_NAME)/$(DATASET_NAME).parquet
 
 save-performance::
 	@mkdir -p $(PERFORMANCE_DIR)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Edit the retain duplicate_geometry_checks code so that it only brings in the expectations for that specific collection not for all collections. 

## Why
When I originally created this change I was not specific enough and expectations were being downloded for sister collections e.g. the area-of-ourstanding-natural-beauty was downloading expectations parquet file article-4-direction-area file and later on when these files were synced back with the s3 bucket in some cases the code was updating expectations parquet files from other collections. This fix will prevent this from happening.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->
- [Ticket Link](https://github.com/digital-land/config/issues/2636)
- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, a note
on the devices and browsers this has been tested on, as well as any relevant
images for UI changes._

## Added/updated tests?
_We encourage you to keep the code coverage percentage at 80% and above. Please refer to the [Digital Land Testing Guidance](https://digital-land.github.io/technical-documentation/development/testing-guidance/) for more information._

- [ ] Yes
- [x] No, and this is why: This is a fix rather than a new feature.
- [ ] I need help with writing tests

I have deployed this to Dev and ran 3 differnt pipelines and I am happy that this make the change I am intending to make.

## [optional] Are there any post deployment tasks we need to perform?

## [optional] Are there any dependencies on other PRs or Work?
